### PR TITLE
Adding Execution to group fix

### DIFF
--- a/TeczterApi/Teczter.Adapters/ExecutionGroupAdapter.cs
+++ b/TeczterApi/Teczter.Adapters/ExecutionGroupAdapter.cs
@@ -26,6 +26,8 @@ public class ExecutionGroupAdapter(TeczterDbContext dbContext) : IExecutionGroup
     {
         return await _dbContext.ExecutionGroups
             .Include(x => x.Executions)
+            .ThenInclude(y => y.Test)
+            .ThenInclude(z => z.TestSteps)
             .SingleOrDefaultAsync(x => x.Id == id && !x.IsDeleted);
     }
 }

--- a/TeczterApi/Teczter.Services/Validation/ExecutionGroupValidator.cs
+++ b/TeczterApi/Teczter.Services/Validation/ExecutionGroupValidator.cs
@@ -1,27 +1,15 @@
 ﻿using FluentValidation;
 using Teczter.Domain.Entities;
-using Teczter.Services.Validation.ValidationRules;
-using Teczter.Services.ValidationRepositoryInterfaces;
 
 namespace Teczter.Services.Validation;
 
 public class ExecutionGroupValidator : AbstractValidator<ExecutionGroupEntity>
 {
-    private readonly IExecutionGroupValidationRepository _validationRepository;
     private readonly IValidator<ExecutionEntity> _executionValidator;
 
-    public ExecutionGroupValidator(IExecutionGroupValidationRepository validationRepository, IValidator<ExecutionEntity> executionValidator)
+    public ExecutionGroupValidator(IValidator<ExecutionEntity> executionValidator)
     {
-        _validationRepository = validationRepository;
         _executionValidator = executionValidator;
-
-        RuleFor(x => x.ExecutionGroupName)
-            .Must(x => ExecutionGroupValidationRules.BeUniqueExecutionGroupName(x, _validationRepository))
-            .WithMessage("An execution group must have a unique name.");
-
-        RuleFor(x => x.SoftwareVersionNumber)
-            .Must(x => ExecutionGroupValidationRules.BeUniqueSoftwareVersionNumberOrNull(x, _validationRepository))
-            .WithMessage("An execution group must have a unique software version number.");
 
         RuleFor(x => x.CreatedOn)
             .Must(y => y > DateTime.MinValue).WithMessage("Invalid Date. please provide a valid date.")

--- a/TeczterApi/Teczter.WebApi/Controllers/ExecutionGroupController.cs
+++ b/TeczterApi/Teczter.WebApi/Controllers/ExecutionGroupController.cs
@@ -115,14 +115,14 @@ public class ExecutionGroupController(IExecutionGroupService executionGroupServi
             return BadRequest("Cannot add new executions to an execution group that has closed.");
         }
 
-        var validatedExecutionGroup = await _executionGroupService.CreateExecution(executionGroup, request);
+        var result = await _executionGroupService.CreateExecution(executionGroup, request);
 
-        if (!validatedExecutionGroup.IsValid)
+        if (!result.IsValid)
         {
-            return BadRequest(validatedExecutionGroup.ErrorMessages);
+            return BadRequest(result.ErrorMessages);
         }
 
-        var dto = new ExecutionGroupDto(validatedExecutionGroup.Value!);
+        var dto = new ExecutionGroupDto(result.Value!);
 
         return CreatedAtAction(nameof(GetExecutionGroup), new { dto.Id }, dto);
     }


### PR DESCRIPTION
Eagerly load nested navigation properties to avoid null exception error and amend validation so that additions to an execution group does not trigger validation as if it where a new group.